### PR TITLE
Replacing the UI once again

### DIFF
--- a/lua/autorun/wowozela.lua
+++ b/lua/autorun/wowozela.lua
@@ -583,7 +583,9 @@ do -- hooks
 end
 
 
-wowozela.sampleSort = {
+
+
+local sampleSort = {
 	["bass"] = "Instrumental",
 	["bass3"] = "Instrumental",
 	["bassguitar2"] = "Instrumental",
@@ -622,8 +624,16 @@ wowozela.sampleSort = {
 	["woof"] = "Misc"
 }
 
-wowozela.sampleSortIcons = {
+for k,v in pairs(sampleSort) do
+	list.Set("wowozela.sampleSort", k, v)
+end
+
+local sampleSortIcons = {
 	["Instrumental"] = "icon16/bell.png",
 	["Synth"] = "icon16/computer.png",
 	["Vocal"] = "icon16/music.png",
 }
+
+for k,v in pairs(sampleSortIcons) do
+	list.Set("wowozela.sampleSortIcons", k, v)
+end

--- a/lua/autorun/wowozela.lua
+++ b/lua/autorun/wowozela.lua
@@ -20,6 +20,14 @@ wowozela.ValidKeys =
 	IN_USE
 }
 
+function wowozela.GetSampleIndex(sampleName)
+	for k,v in pairs(wowozela.Samples) do
+		if v[2] == sampleName then
+			return k
+		end
+	end
+end
+
 if SERVER then
 	for key, value in pairs(wowozela.ValidNotes) do
 		concommand.Add("wowozela_select_" .. key:lower(), function(ply, _, args)

--- a/lua/autorun/wowozela.lua
+++ b/lua/autorun/wowozela.lua
@@ -3,6 +3,68 @@ if not wowozela then wowozela = {} end
 
 if CLIENT then
 	wowozela.volume = CreateClientConVar("wowozela_volume","0.5",true,false)
+
+    function surface.DrawWedge(centerX, centerY, innerRadius, outerRadius, startAng, endAng, numText, nameText)
+        local cir = {}
+        
+        local a = math.rad( startAng )
+        table.insert( cir, { x = centerX + math.sin( a ) * innerRadius, y = centerY + math.cos( a ) * innerRadius, u = math.sin( a ) / 2 + 0.5, v = math.cos( a ) / 2 + 0.5 } )
+        
+        local a = math.rad( startAng )
+        table.insert( cir, { x = centerX + math.sin( a ) * outerRadius, y = centerY + math.cos( a ) * outerRadius, u = math.sin( a ) / 2 + 0.5, v = math.cos( a ) / 2 + 0.5 } )
+        
+        local a = math.rad( endAng )
+        table.insert( cir, { x = centerX + math.sin( a ) * outerRadius, y = centerY + math.cos( a ) * outerRadius, u = math.sin( a ) / 2 + 0.5, v = math.cos( a ) / 2 + 0.5 } )
+    
+        local a = math.rad( endAng )
+        table.insert( cir, { x = centerX + math.sin( a ) * innerRadius, y = centerY + math.cos( a ) * innerRadius, u = math.sin( a ) / 2 + 0.5, v = math.cos( a ) / 2 + 0.5 } )
+        
+        local centerAng = (endAng + startAng) / 2
+        local a = math.rad( centerAng )
+        surface.SetTexture(0)
+        surface.DrawPoly(cir)
+        local rad = ((outerRadius + innerRadius)/2 - 7)
+    
+        draw.Text( {
+            text = numText,
+            pos = { centerX + math.sin( a ) * rad, centerY + math.cos( a ) * rad},
+            xalign = TEXT_ALIGN_CENTER,
+            yalign = TEXT_ALIGN_CENTER
+        } )
+
+        local align = TEXT_ALIGN_CENTER
+
+        if centerAng > 15 and centerAng < 165 then
+            align = TEXT_ALIGN_LEFT
+        elseif centerAng > 195 and centerAng < 345 then
+            align = TEXT_ALIGN_RIGHT
+        end
+
+        draw.Text( {
+            text = nameText,
+            pos = { centerX + math.sin( a ) * outerRadius * 1.05, centerY + math.cos( a ) * outerRadius * 1.05 },
+            xalign = align,
+            yalign = TEXT_ALIGN_CENTER,
+            font = "WowozelaFont2"
+        } )
+	end
+	
+	
+	function wowozela.SetSampleIndex(isLeft, isRight, noteIndex)
+		local done = false
+		if isLeft then
+			RunConsoleCommand("wowozela_select_left", noteIndex)
+			done = true
+		end
+
+		if isRight then
+			RunConsoleCommand("wowozela_select_right", noteIndex)
+			done = true
+		end
+
+		return done
+	end
+
 end
 
 wowozela.ValidNotes =
@@ -27,6 +89,7 @@ function wowozela.GetSampleIndex(sampleName)
 		end
 	end
 end
+
 
 if SERVER then
 	for key, value in pairs(wowozela.ValidNotes) do

--- a/lua/autorun/wowozela.lua
+++ b/lua/autorun/wowozela.lua
@@ -210,7 +210,7 @@ do -- sample meta
 
 	function META:SetSample(i, path)
 		self.CSP[i] = CreateSound(self.Player, path or wowozela.DefaultSound)
-		self.CSP[i]:SetSoundLevel(65)
+		self.CSP[i]:SetSoundLevel(80)
 	end
 
 	function META:ChangeVolume(i, num)

--- a/lua/autorun/wowozela.lua
+++ b/lua/autorun/wowozela.lua
@@ -524,3 +524,49 @@ do -- hooks
 		end
 	end
 end
+
+
+wowozela.sampleSort = {
+	["bass"] = "Instrumental",
+	["bass3"] = "Instrumental",
+	["bassguitar2"] = "Instrumental",
+	["bell"] = "Instrumental",
+	["coolchiff"] = "Instrumental",
+	["crackpiano"] = "Instrumental",
+	["dingdong"] = "Instrumental",
+	["dooooooooh"] = "Vocal",
+	["dusktodawn"] = "Synth",
+	["flute"] = "Instrumental",
+	["fmbass"] = "Instrumental",
+	["fuzz"] = "Instrumental",
+	["guitar"] = "Instrumental",
+	["hit"] = "Instrumental",
+	["honkytonk"] = "Instrumental",
+	["horn"] = "Misc",
+	["justice"] = "Instrumental",
+	["littleflower"] = "Instrumental",
+	["meow"] = "Misc",
+	["miku"] = "Vocal",
+	["mmm"] = "Vocal",
+	["oohh"] = "Vocal",
+	["overdrive"] = "Misc",
+	["pianostab"] = "Instrumental",
+	["prima"] = "Vocal",
+	["quack"] = "Misc",
+	["saw_880"] = "Synth",
+	["sine_880"] = "Synth",
+	["skull"] = "Instrumental",
+	["slap"] = "Instrumental",
+	["square_880"] = "Synth",
+	["string"] = "Instrumental",
+	["toypiano"] = "Instrumental",
+	["triangle_880"] = "Synth",
+	["trumpet"] = "Instrumental",
+	["woof"] = "Misc"
+}
+
+wowozela.sampleSortIcons = {
+	["Instrumental"] = "icon16/bell.png",
+	["Synth"] = "icon16/computer.png",
+	["Vocal"] = "icon16/music.png",
+}

--- a/lua/autorun/wowozela.lua
+++ b/lua/autorun/wowozela.lua
@@ -456,9 +456,9 @@ do -- hooks
 	hook.Add("KeyPress", "wowozela_keypress", function(ply, key)
 		if not IsFirstTimePredicted() then return end
 		
+		
 		local wep = ply:GetActiveWeapon()
 		if wep:IsValid() and wep:GetClass() == "wowozela" then
-			local wep = ply:GetActiveWeapon()
 			if wowozela.IsValidKey(key) then
 				if SERVER and wep.OnKeyEvent then
 					wowozela.BroadcastKeyEvent(ply, key, true)

--- a/lua/autorun/wowozela.lua
+++ b/lua/autorun/wowozela.lua
@@ -4,52 +4,51 @@ if not wowozela then wowozela = {} end
 if CLIENT then
 	wowozela.volume = CreateClientConVar("wowozela_volume","0.5",true,false)
 
-    function surface.DrawWedge(centerX, centerY, innerRadius, outerRadius, startAng, endAng, numText, nameText)
-        local cir = {}
-        
-        local a = math.rad( startAng )
-        table.insert( cir, { x = centerX + math.sin( a ) * innerRadius, y = centerY + math.cos( a ) * innerRadius, u = math.sin( a ) / 2 + 0.5, v = math.cos( a ) / 2 + 0.5 } )
-        
-        local a = math.rad( startAng )
-        table.insert( cir, { x = centerX + math.sin( a ) * outerRadius, y = centerY + math.cos( a ) * outerRadius, u = math.sin( a ) / 2 + 0.5, v = math.cos( a ) / 2 + 0.5 } )
-        
-        local a = math.rad( endAng )
-        table.insert( cir, { x = centerX + math.sin( a ) * outerRadius, y = centerY + math.cos( a ) * outerRadius, u = math.sin( a ) / 2 + 0.5, v = math.cos( a ) / 2 + 0.5 } )
-    
-        local a = math.rad( endAng )
-        table.insert( cir, { x = centerX + math.sin( a ) * innerRadius, y = centerY + math.cos( a ) * innerRadius, u = math.sin( a ) / 2 + 0.5, v = math.cos( a ) / 2 + 0.5 } )
-        
-        local centerAng = (endAng + startAng) / 2
-        local a = math.rad( centerAng )
-        surface.SetTexture(0)
-        surface.DrawPoly(cir)
-        local rad = ((outerRadius + innerRadius)/2 - 7)
-    
-        draw.Text( {
-            text = numText,
-            pos = { centerX + math.sin( a ) * rad, centerY + math.cos( a ) * rad},
-            xalign = TEXT_ALIGN_CENTER,
-            yalign = TEXT_ALIGN_CENTER
-        } )
+	function surface.DrawWedge(centerX, centerY, innerRadius, outerRadius, startAng, endAng, numText, nameText)
+		local cir = {}
 
-        local align = TEXT_ALIGN_CENTER
+		local a = math.rad( startAng )
+		table.insert( cir, { x = centerX + math.sin( a ) * innerRadius, y = centerY + math.cos( a ) * innerRadius, u = math.sin( a ) / 2 + 0.5, v = math.cos( a ) / 2 + 0.5 } )
 
-        if centerAng > 15 and centerAng < 165 then
-            align = TEXT_ALIGN_LEFT
-        elseif centerAng > 195 and centerAng < 345 then
-            align = TEXT_ALIGN_RIGHT
-        end
+		a = math.rad( startAng )
+		table.insert( cir, { x = centerX + math.sin( a ) * outerRadius, y = centerY + math.cos( a ) * outerRadius, u = math.sin( a ) / 2 + 0.5, v = math.cos( a ) / 2 + 0.5 } )
 
-        draw.Text( {
-            text = nameText,
-            pos = { centerX + math.sin( a ) * outerRadius * 1.05, centerY + math.cos( a ) * outerRadius * 1.05 },
-            xalign = align,
-            yalign = TEXT_ALIGN_CENTER,
-            font = "WowozelaFont2"
-        } )
+		a = math.rad( endAng )
+		table.insert( cir, { x = centerX + math.sin( a ) * outerRadius, y = centerY + math.cos( a ) * outerRadius, u = math.sin( a ) / 2 + 0.5, v = math.cos( a ) / 2 + 0.5 } )
+
+		a = math.rad( endAng )
+		table.insert( cir, { x = centerX + math.sin( a ) * innerRadius, y = centerY + math.cos( a ) * innerRadius, u = math.sin( a ) / 2 + 0.5, v = math.cos( a ) / 2 + 0.5 } )
+
+		local centerAng = (endAng + startAng) / 2
+		a = math.rad( centerAng )
+		surface.SetTexture(0)
+		surface.DrawPoly(cir)
+		local rad = ((outerRadius + innerRadius) / 2 - 7)
+
+		draw.Text( {
+		    text = numText,
+		    pos = { centerX + math.sin( a ) * rad, centerY + math.cos( a ) * rad},
+		    xalign = TEXT_ALIGN_CENTER,
+		    yalign = TEXT_ALIGN_CENTER
+		} )
+
+		local align = TEXT_ALIGN_CENTER
+
+		if centerAng > 15 and centerAng < 165 then
+		    align = TEXT_ALIGN_LEFT
+		elseif centerAng > 195 and centerAng < 345 then
+		    align = TEXT_ALIGN_RIGHT
+		end
+
+		draw.Text( {
+		    text = nameText,
+		    pos = { centerX + math.sin( a ) * outerRadius * 1.05, centerY + math.cos( a ) * outerRadius * 1.05 },
+		    xalign = align,
+		    yalign = TEXT_ALIGN_CENTER,
+		    font = "WowozelaFont2"
+		} )
 	end
-	
-	
+
 	function wowozela.SetSampleIndex(isLeft, isRight, noteIndex)
 		local done = false
 		if isLeft then
@@ -96,14 +95,14 @@ if SERVER then
 		concommand.Add("wowozela_select_" .. key:lower(), function(ply, _, args)
 			local wep = ply:GetActiveWeapon()
 			if wep:IsValid() and wep:GetClass() == "wowozela" then
-				
+
 				local val = tonumber(args[1]) or 1
 				local test = "SetNote" .. key -- naughty
-				
+
 				if wep[test] then
 					wep[test](wep, val)
 				end
-			end		
+			end
 		end)
 	end
 	wowozela.Samples = {}
@@ -147,9 +146,8 @@ if SERVER then
 	}
 
 	for _, file_name in pairs(file.Find("sound/wowozela/samples/*.wav", "GAME")) do
-		
 		table.insert(wowozela.Samples, {"wowozela/samples/" .. file_name, file_name:match("(.+)%.wav")})
-		
+
 		if SERVER then
 			if not workshopSounds[file_name] then
 				resource.AddFile("sound/wowozela/samples/" .. file_name)
@@ -202,7 +200,7 @@ end
 function wowozela.IsValidNote(key)
 	for k,v in pairs(wowozela.ValidNotes) do
 		if v == key then
-			return k 
+			return k
 		end
 	end
 	return false
@@ -253,7 +251,7 @@ do -- sample meta
 		if self.Player == LocalPlayer() and not self.Player:ShouldDrawLocalPlayer() then
 			return self.Player:EyePos()
 		end
-		
+
 		local id = self.Player:LookupBone("ValveBiped.Bip01_Head1")
 		local pos = id and self.Player:GetBonePosition(id)
 		return pos or self.Player:EyePos()
@@ -261,11 +259,11 @@ do -- sample meta
 
 	function META:GetAngles()
 		local ang = self.Player:GetAimVector():Angle()
-		
+
 		ang.p = math.NormalizeAngle(ang.p)
 		ang.y = math.NormalizeAngle(ang.y)
 		ang.r = 0
-		
+
 		return ang
 	end
 
@@ -302,7 +300,7 @@ do -- sample meta
 		if self:IsKeyDown(IN_WALK) then
 			num = num - 1
 		end
-		
+
 		self.Pitch = math.Clamp(math.floor(100 * 2 ^ num), 1, 255)
 
 		for i in pairs(wowozela.Samples) do
@@ -360,18 +358,18 @@ do -- sample meta
 			if press then
 				if self:IsKeyDown(IN_SPEED) and self.Player == LocalPlayer() then
 					local ang = self.Player:EyeAngles()
-					
+
 					local p = ang.p / 89 -- -1 to 1
 					p = (p + 1) / 2 -- 0 to 1
 					p = p * 12 -- 0 to 12
-					p = math.Round(p*2)/2 -- rounded
+					p = math.Round(p * 2) / 2 -- rounded
 					p = p / 12
 					p = (p * 2) - 1
-					
+
 					ang.p = p * 89
 					self.Player:SetEyeAngles(ang)
 				end
-			
+
 				self:Start(id, key)
 				self:SetVolume(1)
 			else
@@ -382,12 +380,12 @@ do -- sample meta
 
 	function META:Think()
 		if not self:CanPlay() then
-			for _, csp in pairs(self.CSP) do 
+			for _, csp in pairs(self.CSP) do
 				csp:Stop()
 			end
 			return
 		end
-	
+
 		local ang = self:GetAngles()
 
 		if self:IsKeyDown(IN_USE) then
@@ -401,7 +399,7 @@ do -- sample meta
 			self:SetVolume(1)
 		end
 
-		self:SetPitch(-ang.p/89)
+		self:SetPitch(-ang.p / 89)
 
 		if self:IsKeyDown(IN_ATTACK) or self:IsKeyDown(IN_ATTACK2) then
 			self:MakeParticle()
@@ -412,16 +410,16 @@ do -- sample meta
 
 	function META:MakeParticle()
 		local pitch = self.Pitch
-		
+
 		emitter = emitter or ParticleEmitter(Vector())
-		
+
 		local scale = self.Player:GetModelScale()
-		
+
 		local forward = self:GetAngles():Forward()
 		local particle = emitter:Add("particle/fire", self:GetPos() + forward * 10 * scale)
-		
+
 		if particle then
-			local col = HSVToColor(pitch*2.55, self.Volume, 1)
+			local col = HSVToColor(pitch * 2.55, self.Volume, 1)
 			particle:SetColor(col.r, col.g, col.b, self.Volume)
 
 			particle:SetVelocity(self.Volume * self:GetAngles():Forward() * 500 * scale)
@@ -432,10 +430,10 @@ do -- sample meta
 			local size = ((-pitch + 255) / 250) + 1
 
 			particle:SetAngles(AngleRand())
-			particle:SetStartSize(math.max(size*2*scale, 1) * 1.5)
+			particle:SetStartSize(math.max(size * 2 * scale, 1) * 1.5)
 			particle:SetEndSize(0)
 
-			particle:SetStartAlpha(255*self.Volume)
+			particle:SetStartAlpha(255 * self.Volume)
 			particle:SetEndAlpha(0)
 
 			--particle:SetRollDelta(math.Rand(-1,1)*20)
@@ -468,7 +466,7 @@ do -- hooks
 
 		local sampler = ply:GetSampler()
 		if sampler and sampler.OnKeyEvent and ply == sampler.Player then
-			
+
 			sampler.Keys[key] = press
 
 			return sampler:OnKeyEvent(key, press)
@@ -499,7 +497,7 @@ do -- hooks
 	hook.Add("Think", "wowozela_think", wowozela.Think)
 
 
-	
+
 	function wowozela.Draw()
 		for key, ply in pairs(player.GetAll()) do
 			local sampler = ply:GetSampler()
@@ -521,24 +519,22 @@ do -- hooks
 			net.SendOmit(ply)
 		else
 			net.Broadcast()
-		end 
+		end
 	end
 
 	hook.Add("KeyPress", "wowozela_keypress", function(ply, key)
 		if not IsFirstTimePredicted() then return end
-		
-		
-		local wep = ply:GetActiveWeapon()
-		if wep:IsValid() and wep:GetClass() == "wowozela" then
-			if wowozela.IsValidKey(key) then
-				if SERVER and wep.OnKeyEvent then
-					wowozela.BroadcastKeyEvent(ply, key, true)
-					wep:OnKeyEvent(key, true)
-				end
 
-				if CLIENT then
-					wowozela.KeyEvent(ply, key, true)
-				end
+
+		local wep = ply:GetActiveWeapon()
+		if wep:IsValid() and wep:GetClass() == "wowozela" and wowozela.IsValidKey(key) then
+			if SERVER and wep.OnKeyEvent then
+				wowozela.BroadcastKeyEvent(ply, key, true)
+				wep:OnKeyEvent(key, true)
+			end
+
+			if CLIENT then
+				wowozela.KeyEvent(ply, key, true)
 			end
 		end
 	end)
@@ -547,16 +543,14 @@ do -- hooks
 		if not IsFirstTimePredicted() then return end
 
 		local wep = ply:GetActiveWeapon()
-		if wep:IsValid() and wep:GetClass() == "wowozela" then
-			if wowozela.IsValidKey(key) then
-				if SERVER and wep.OnKeyEvent then
-					wowozela.BroadcastKeyEvent(ply, key, false)
-					wep:OnKeyEvent(key, false)
-				end
+		if wep:IsValid() and wep:GetClass() == "wowozela" and wowozela.IsValidKey(key) then
+			if SERVER and wep.OnKeyEvent then
+				wowozela.BroadcastKeyEvent(ply, key, false)
+				wep:OnKeyEvent(key, false)
+			end
 
-				if CLIENT then
-					wowozela.KeyEvent(ply, key, false)
-				end
+			if CLIENT then
+				wowozela.KeyEvent(ply, key, false)
 			end
 		end
 	end)
@@ -570,7 +564,7 @@ do -- hooks
 				wowozela.KeyEvent(ply, key, press)
 			end
 		end)
-		
+
 		RunConsoleCommand("wowozela_request_samples")
 	else
 		hook.Add("PlayerInitialSpawn", "WowozelaPlayerJoined", function(ply)

--- a/lua/weapons/wowozela.lua
+++ b/lua/weapons/wowozela.lua
@@ -279,6 +279,7 @@ if CLIENT then
 
             local farEnough = testDist(ScrW()/2, ScrH()/2, mouseX, mouseY) > 36 * 36
 
+            draw.NoTexture()
             surface.SetDrawColor(Color(100, 100, 100, 75))
             drawCircle(ScrW()/2, ScrH()/2, 36, 10)
 

--- a/lua/weapons/wowozela.lua
+++ b/lua/weapons/wowozela.lua
@@ -254,7 +254,7 @@ if CLIENT then
     local function generateTable()
         local tbl, tbl2 = {}, {}
         for k,v in pairs(wowozela.Samples) do
-            local t = wowozela.sampleSort[v[2]]
+            local t = list.Get("wowozela.sampleSort")[v[2]]
             if t then
                 if not tbl[t] then
                     tbl[t] = {}
@@ -293,8 +293,9 @@ if CLIENT then
                             local snds = tbl[cat]
 
                             local t, t2 = Menu:AddSubMenu(cat)
-                            if wowozela.sampleSortIcons[cat] then
-                                t2:SetIcon(wowozela.sampleSortIcons[cat])
+                            local icons = list.Get("wowozela.sampleSortIcons")
+                            if icons[cat] then
+                                t2:SetIcon(icons[cat])
                             end
 
                             for _, snd in pairs(snds) do

--- a/lua/weapons/wowozela.lua
+++ b/lua/weapons/wowozela.lua
@@ -392,6 +392,7 @@ if CLIENT then
         end
         return tbl
     end
+
     hook.Add("PlayerBindPress", "WowozelaBindPress", function(ply, bind, pressed)
         local wep = ply:GetActiveWeapon() 
         if IsValid(wep) and wep:GetClass() == "wowozela" then
@@ -404,20 +405,13 @@ if CLIENT then
                         local Menu = DermaMenu()
                         
                         for cat,snds in pairs(generateTable()) do
-    
                             local t = Menu:AddSubMenu(cat)
                             for _, snd in pairs(snds) do 
                                 t:AddOption(snd, function()
                                     wep.Wedges[selectionData.layout][selectionData[3]] = snd
                                     file.Write("wowozela.txt", util.TableToJSON(wep.Wedges, true))
-    
-                                    local noteIndex = nil
-                                    for k,v in pairs(wowozela.Samples) do
-                                        if v[2] == snd then
-                                            noteIndex = k
-                                        end
-                                    end
-    
+
+                                    local noteIndex = wowozela.GetSampleIndex(snd)
                                     if noteIndex then
                                         if selectionData[1] then
                                             RunConsoleCommand("wowozela_select_left", noteIndex)
@@ -448,45 +442,22 @@ if CLIENT then
                     return true
                 end
             elseif ply:KeyDown(IN_ATTACK) or ply:KeyDown(IN_ATTACK2) then
-
                 local num = tonumber(bind:match("slot(%d+)"))
                 if num and pressed then
                     if num == 0 then num = 10 end
-
-                    local noteIndex = nil
                     if wep.Wedges and wep.CurrentLayout and wep.Wedges[wep.CurrentLayout] and wep.Wedges[wep.CurrentLayout][num] then
-                        for k,v in pairs(wowozela.Samples) do
-                            if v[2] == wep.Wedges[wep.CurrentLayout][num] then
-                                noteIndex = k
+                        local noteIndex = wowozela.GetSampleIndex(wep.Wedges[wep.CurrentLayout][num])
+                        if noteIndex then
+                            if ply:KeyDown(IN_ATTACK) then
+                                RunConsoleCommand("wowozela_select_left", noteIndex)
+                                selectionIndex = nil
                             end
-                        end
-                    end
-
-                    if noteIndex then
-                        local sampler = ply:GetSampler() 
-                        if ply:KeyDown(IN_ATTACK) then
-                            RunConsoleCommand("wowozela_select_left", noteIndex)
-                            selectionIndex = nil
-
-                            if sampler then
-                                sampler:OnKeyEvent(IN_ATTACK, false)
-                                timer.Simple(0, function()
-                                    sampler:OnKeyEvent(IN_ATTACK, true)
-                                end)
-                            end
-                        end
-            
-                        if ply:KeyDown(IN_ATTACK2) then
-                            RunConsoleCommand("wowozela_select_right", noteIndex)
-                            selectionIndex = nil
-
-                            if sampler then
-                                sampler:OnKeyEvent(IN_ATTACK2, false)
-                                timer.Simple(0, function()
-                                    sampler:OnKeyEvent(IN_ATTACK2, true)
-                                end)
-                            end
-                        end 
+                
+                            if ply:KeyDown(IN_ATTACK2) then
+                                RunConsoleCommand("wowozela_select_right", noteIndex)
+                                selectionIndex = nil
+                            end 
+                        end  
                     end
                     return true
                 end
@@ -499,29 +470,20 @@ if CLIENT then
         if IsValid(wep) and wep:GetClass() == "wowozela" and selectionIndex then
             local isLeft, isRight, noteWedgeIndex = unpack(selectionIndex)
 
-
-            local noteIndex = nil
             if wep.Wedges and wep.CurrentLayout and wep.Wedges[wep.CurrentLayout] and wep.Wedges[wep.CurrentLayout][noteWedgeIndex] then
-                for k,v in pairs(wowozela.Samples) do
-                    if v[2] == wep.Wedges[wep.CurrentLayout][noteWedgeIndex] then
-                        noteIndex = k
+                local noteIndex = wowozela.GetSampleIndex(wep.Wedges[wep.CurrentLayout][noteWedgeIndex])
+                if noteIndex then
+                    if isLeft and key == IN_ATTACK then
+                        RunConsoleCommand("wowozela_select_left", noteIndex)
+                        selectionIndex = nil
+                    end
+        
+                    if isRight and key == IN_ATTACK2 then
+                        RunConsoleCommand("wowozela_select_right", noteIndex)
+                        selectionIndex = nil
                     end
                 end
             end
-
-
-            if noteIndex then
-                if isLeft and key == IN_ATTACK then
-                    RunConsoleCommand("wowozela_select_left", noteIndex)
-                    selectionIndex = nil
-                end
-    
-                if isRight and key == IN_ATTACK2 then
-                    RunConsoleCommand("wowozela_select_right", noteIndex)
-                    selectionIndex = nil
-                end
-            end
-            
         end
     end)
 end

--- a/lua/weapons/wowozela.lua
+++ b/lua/weapons/wowozela.lua
@@ -10,7 +10,7 @@ if wowozela == nil then
     wowozela.ValidKeys =
     {
         IN_ATTACK,
-	    IN_ATTACK2,
+        IN_ATTACK2,
         IN_WALK,
         IN_SPEED,
         IN_USE
@@ -69,7 +69,6 @@ function SWEP:Initialize()
     if self.SetWeaponHoldType then
         self:SetWeaponHoldType("normal")
     end
-    
 
     self.CurrentLayout = 1
     self:SetNoteLeft(1)
@@ -88,10 +87,9 @@ function SWEP:Deploy()
 end
 
 function SWEP:Holster()
-    if not self.Owner:KeyDown(IN_RELOAD) then
+    if not self:GetOwner():KeyDown(IN_RELOAD) then
         return true
     end
-    
     return false
 end
 
@@ -100,8 +98,8 @@ function SWEP:OnKeyEvent(key, press)
 end
 
 function SWEP:_Think()
-    if self.Owner and self.Owner:IsValid() and self.Owner:GetViewModel():IsValid() then
-        self.Owner:GetViewModel():SetNoDraw(true)
+    if self:GetOwner() and self:GetOwner():IsValid() and self:GetOwner():GetViewModel():IsValid() then
+        self:GetOwner():GetViewModel():SetNoDraw(true)
         self.Think = nil
     end
 end
@@ -122,8 +120,7 @@ end)
 
 if CLIENT then
     local size = 80
-    local count = 4
-    
+
     surface.CreateFont(
         "WowozelaFont",
         {
@@ -132,7 +129,7 @@ if CLIENT then
             weight		= 1000,
         }
     )
-    
+
     surface.CreateFont(
         "WowozelaFont2",
         {
@@ -142,35 +139,15 @@ if CLIENT then
         }
     )
     local wason = false
-    local selection1 = 1
-    local selection2 = 1
-    local alpha = 0
-    local showing = 5
-    
-    local space = 10
-    local size_diagy
-    local maxheight = 0
-    local indexs = {}
-    local PanelWidth = ScrW() * 0.75
-    local function PosToIndex(posX)
-        --local posX = size_diag - posX
-        for k,v in pairs(indexs) do
-            if posX > v[1] and posX <= v[2] then
-                return k
-            end 
-        end
-        return 1
-    end
-    
+
     local selectionIndex = nil
-    local wason = false
     local function testDist(x, y, x2, y2)
         return math.pow(y2 - y, 2) + math.pow(x2 - x, 2)
     end
 
     function SWEP:LoadWedges()
         self.Wedges = {}
-        for I=1,10 do table.insert(self.Wedges, {}) end
+        for I = 1, 10 do table.insert(self.Wedges, {}) end
 
         if file.Exists("wowozela.txt", "DATA") then
             self.Wedges = util.JSONToTable(file.Read("wowozela.txt", "DATA"))
@@ -178,7 +155,7 @@ if CLIENT then
     end
 
     function SWEP:HUDShouldDraw(element)
-        if self.Owner:KeyDown(IN_RELOAD) and element == "CHudCrosshair" then
+        if self:GetOwner():KeyDown(IN_RELOAD) and element == "CHudCrosshair" then
             return false
         end
         return true
@@ -189,72 +166,70 @@ if CLIENT then
             self:LoadWedges()
             return
         end
-        
-        if not self.Wedges[self.CurrentLayout] then 
+
+        if not self.Wedges[self.CurrentLayout] then
             self.Wedges[self.CurrentLayout] = {}
         end
 
         local mouseX, mouseY = gui.MouseX(), gui.MouseY()
-        
+
         local function drawCircle( x, y, radius, seg )
             local cir = {}
-        
+
             table.insert( cir, { x = x, y = y, u = 0.5, v = 0.5 } )
             for i = 0, seg do
                 local a = math.rad( ( i / seg ) * -360 )
                 table.insert( cir, { x = x + math.sin( a ) * radius, y = y + math.cos( a ) * radius, u = math.sin( a ) / 2 + 0.5, v = math.cos( a ) / 2 + 0.5 } )
             end
-        
+
             local a = math.rad( 0 ) -- This is needed for non absolute segment counts
             table.insert( cir, { x = x + math.sin( a ) * radius, y = y + math.cos( a ) * radius, u = math.sin( a ) / 2 + 0.5, v = math.cos( a ) / 2 + 0.5 } )
-        
+
             surface.DrawPoly( cir )
         end
 
-        if self.Owner:KeyDown(IN_RELOAD) then
-            
-            local editing = self.Owner:KeyDown(IN_ATTACK) or self.Owner:KeyDown(IN_ATTACK2)
-            local ang = math.atan2(mouseY - ScrH()/2, ScrW()/2 - mouseX)
+        if self:GetOwner():KeyDown(IN_RELOAD) then
+
+            local editing = self:GetOwner():KeyDown(IN_ATTACK) or self:GetOwner():KeyDown(IN_ATTACK2)
+            local ang = math.atan2(mouseY - ScrH() / 2, ScrW() / 2 - mouseX)
             local ang2 = (math.deg(ang) - 90) % 360
-            local wedgeSize = (36)
+            local wedgeSize = 36
             local wedge2 = wedgeSize
             local hoverWedge = nil
-            local farEnough = testDist(ScrW()/2, ScrH()/2, mouseX, mouseY) > 36 * 36
+            local farEnough = testDist(ScrW() / 2, ScrH() / 2, mouseX, mouseY) > 36 * 36
 
             draw.NoTexture()
             surface.SetDrawColor(Color(100, 100, 100, 75))
-            drawCircle(ScrW()/2, ScrH()/2, 36, 10)
+            drawCircle(ScrW() / 2, ScrH() / 2, 36, 10)
 
             draw.Text( {
                 text = tostring(self.CurrentLayout == 10 and 0 or self.CurrentLayout),
-                pos = { ScrW()/2, ScrH()/2 },
+                pos = { ScrW() / 2, ScrH() / 2 },
                 xalign = TEXT_ALIGN_CENTER,
                 yalign = TEXT_ALIGN_CENTER,
                 font = "WowozelaFont2",
                 color = Color(255, 255, 255, 255)
             } )
 
-            for I=1, (360/wedgeSize) do
+            for I = 1, (360 / wedgeSize) do
                 local wedgeAng = ((I - 1) * wedgeSize)
                 local col = HSVToColor(wedgeAng, 1, 0.75)
                 col.a = 150
-                
-                if editing then 
-                    if ang2 >= (wedgeAng) and ang2 <= (wedgeAng + wedge2) and farEnough then
-                        hoverWedge = I
-                        col = HSVToColor(wedgeAng, 1, 0.5)
-                        col.a = 150
-                    end
+
+                if editing and ang2 >= wedgeAng and ang2 <= (wedgeAng + wedge2) and farEnough then
+                    hoverWedge = I
+                    col = HSVToColor(wedgeAng, 1, 0.5)
+                    col.a = 150
                 end
 
                 surface.SetDrawColor(col)
-                surface.DrawWedge(ScrW()/2, ScrH()/2, 130, 150, wedgeAng, wedgeAng + wedge2, string.format("%d", I == 10 and 0 or I), ("%s"):format(self.Wedges[self.CurrentLayout][I] or "(unassigned)"))
+                surface.DrawWedge(ScrW() / 2, ScrH() / 2, 130, 150, wedgeAng, wedgeAng + wedge2, string.format("%d", I == 10 and 0 or I), ("%s"):format(self.Wedges[self.CurrentLayout][I] or "(unassigned)"))
 
                 col.a = 50
                 surface.SetDrawColor(col)
-                surface.DrawWedge(ScrW()/2, ScrH()/2, 36, 130, wedgeAng, wedgeAng + wedge2, "", "")
+                surface.DrawWedge(ScrW() / 2, ScrH() / 2, 36, 130, wedgeAng, wedgeAng + wedge2, "", "")
             end
-            
+
             if editing then
                 if not wason then
                     gui.EnableScreenClicker(true)
@@ -262,7 +237,7 @@ if CLIENT then
                 end
 
                 if hoverWedge and farEnough then
-                    selectionIndex = {self.Owner:KeyDown(IN_ATTACK), self.Owner:KeyDown(IN_ATTACK2), hoverWedge, self.Wedges[self.CurrentLayout][hoverWedge]}
+                    selectionIndex = {self:GetOwner():KeyDown(IN_ATTACK), self:GetOwner():KeyDown(IN_ATTACK2), hoverWedge, self.Wedges[self.CurrentLayout][hoverWedge]}
                 else
                     selectionIndex = nil
                 end
@@ -304,14 +279,14 @@ if CLIENT then
     end
 
     hook.Add("PlayerBindPress", "WowozelaBindPress", function(ply, bind, pressed)
-        local wep = ply:GetActiveWeapon() 
+        local wep = ply:GetActiveWeapon()
         if IsValid(wep) and wep:GetClass() == "wowozela" then
-            if ply:KeyDown(IN_RELOAD) then 
+            if ply:KeyDown(IN_RELOAD) then
                 if bind == "+menu" and pressed then
                     if selectionIndex and wep.CurrentLayout then
                         local tbl, tbl2 = generateTable()
                         local selectionData = table.Copy(selectionIndex)
-                        selectionData.layout = wep.CurrentLayout 
+                        selectionData.layout = wep.CurrentLayout
 
                         local Menu = DermaMenu()
                         for _, cat in pairs(tbl2) do
@@ -322,7 +297,7 @@ if CLIENT then
                                 t2:SetIcon(wowozela.sampleSortIcons[cat])
                             end
 
-                            for _, snd in pairs(snds) do 
+                            for _, snd in pairs(snds) do
                                 t:AddOption(snd, function()
                                     wep.Wedges[selectionData.layout][selectionData[3]] = snd
                                     file.Write("wowozela.txt", util.TableToJSON(wep.Wedges, true))
@@ -338,13 +313,11 @@ if CLIENT then
                     end
                     return true
                 end
-    
                 local num = tonumber(bind:match("slot(%d+)"))
                 if num and pressed then
                     if num == 0 then num = 10 end
 
                     if wep.Wedges[num] then
-                        
                         wep.CurrentLayout = num
                     end
                     return true
@@ -361,12 +334,12 @@ if CLIENT then
                     end
                     return true
                 end
-            end 
+            end
         end
     end)
 
     hook.Add("KeyRelease", "WowozelaFinalizeSelection", function(ply, key)
-        local wep = ply:GetActiveWeapon() 
+        local wep = ply:GetActiveWeapon()
         if IsValid(wep) and wep:GetClass() == "wowozela" and selectionIndex then
             local isLeft, isRight, noteWedgeIndex = unpack(selectionIndex)
 

--- a/lua/weapons/wowozela.lua
+++ b/lua/weapons/wowozela.lua
@@ -335,62 +335,31 @@ if CLIENT then
         end
     end
 
-	wowozela.sampleSort = {
-		["bass"] = "Instrumental",
-		["bass3"] = "Instrumental",
-		["bassguitar2"] = "Instrumental",
-		["bell"] = "Instrumental",
-		["coolchiff"] = "Instrumental",
-		["crackpiano"] = "Instrumental",
-		["dingdong"] = "Instrumental",
-		["dooooooooh"] = "Vocal",
-		["dusktodawn"] = "Synth",
-		["flute"] = "Instrumental",
-		["fmbass"] = "Instrumental",
-		["fuzz"] = "Instrumental",
-		["guitar"] = "Instrumental",
-		["hit"] = "Instrumental",
-		["honkytonk"] = "Synth",
-		["horn"] = "Misc",
-		["justice"] = "Synth",
-		["littleflower"] = "Instrumental",
-		["meow"] = "Misc",
-		["miku"] = "Vocal",
-		["mmm"] = "Vocal",
-		["oohh"] = "Vocal",
-		["overdrive"] = "Misc",
-		["pianostab"] = "Instrumental",
-		["prima"] = "Vocal",
-		["quack"] = "Misc",
-		["saw_880"] = "Synth",
-		["sine_880"] = "Synth",
-		["skull"] = "Instrumental",
-		["slap"] = "Synth",
-		["square_880"] = "Synth",
-		["string"] = "Instrumental",
-		["toypiano"] = "Instrumental",
-		["triangle_880"] = "Synth",
-		["trumpet"] = "Instrumental",
-		["woof"] = "Misc"
-    }
-    
     local function generateTable()
-        local tbl = {}
+        local tbl, tbl2 = {}, {}
         for k,v in pairs(wowozela.Samples) do
             local t = wowozela.sampleSort[v[2]]
             if t then
                 if not tbl[t] then
                     tbl[t] = {}
+                    table.insert(tbl2, t)
                 end
                 table.insert(tbl[t], v[2])
+
+                table.sort(tbl[t])
             else
                 if not tbl.Custom then
                     tbl.Custom = {}
+                    table.insert(tbl2, "Custom")
                 end
                 table.insert(tbl.Custom, v[2])
+
+                table.sort(tbl.Custom)
             end
         end
-        return tbl
+
+        table.sort(tbl2)
+        return tbl, tbl2
     end
 
     hook.Add("PlayerBindPress", "WowozelaBindPress", function(ply, bind, pressed)
@@ -399,13 +368,22 @@ if CLIENT then
             if ply:KeyDown(IN_RELOAD) then 
                 if bind == "+menu" and pressed then
                     if selectionIndex and wep.CurrentLayout then
+                        local tbl, tbl2 = generateTable()
                         local selectionData = table.Copy(selectionIndex)
     
                         selectionData.layout = wep.CurrentLayout 
                         local Menu = DermaMenu()
                         
-                        for cat,snds in pairs(generateTable()) do
-                            local t = Menu:AddSubMenu(cat)
+                        
+                        for _, cat in pairs(tbl2) do
+                            local snds = tbl[cat]
+
+                            local t, t2 = Menu:AddSubMenu(cat)
+
+                            if wowozela.sampleSortIcons[cat] then
+                                t2:SetIcon(wowozela.sampleSortIcons[cat])
+                            end
+
                             for _, snd in pairs(snds) do 
                                 t:AddOption(snd, function()
                                     wep.Wedges[selectionData.layout][selectionData[3]] = snd


### PR DESCRIPTION
This time more of a radial menu, where each wedge can be set to sounds instead of just displaying them all. There is 10 preset (select with slot1-slot10 binds while pressing reload) radial menus. 
![Radial Menu](https://storage.googleapis.com/katieshares/LazyDarkolivegreenVoluminousSiskin.png)

Pressing a +menu bind on a wedge will change it
![Selecting a sound](https://storage.googleapis.com/katieshares/PlumShadyCurvyRockrat.png)

